### PR TITLE
Fix few bugs while I was working to convert some BDF to PNG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.pyc
 
+.vscode/

--- a/monobit/bdf.py
+++ b/monobit/bdf.py
@@ -350,7 +350,7 @@ def _parse_xlfd_name(xlfd_str):
     """Parse X logical font description font name string."""
     xlfd = xlfd_str.split('-')
     if len(xlfd) == 15:
-        properties = {_key: _value for _key, _value in zip(_XLFD_NAME_FIELDS, xlfd) if _key}
+        properties = {_key: _value for _key, _value in zip(_XLFD_NAME_FIELDS, xlfd) if _key and _value}
     else:
         logging.warning('Could not parse X font name string `%s`', xlfd_str)
         return {}

--- a/monobit/formats.py
+++ b/monobit/formats.py
@@ -304,7 +304,7 @@ def _single_saver(save, pack, outfile, binary, ext, **kwargs):
         outfile = sys.stdout.buffer
     if len(pack) == 1:
         # we have only one font to deal with, no need to create container
-        _multi_saver(save, [*pack][0], outfile, binary)
+        _multi_saver(save, [*pack][0], outfile, binary, **kwargs)
     else:
         # create container and call saver for each font in the pack
         with _open_container(outfile, 'w', binary) as out:

--- a/monobit/image.py
+++ b/monobit/image.py
@@ -108,14 +108,13 @@ def _to_image(
     # work out image geometry
     step_x = font.bounding_box.x * scale_x + padding_x
     step_y = font.bounding_box.y * scale_y + padding_y
-    glyphs = [_glyph for _, _glyph in font.iter_ordinal(encoding=encoding)]
-    rows = ceildiv(len(glyphs), columns)
+    rows = ceildiv(len(font.glyphs), columns)
     # determine image geometry
     width = columns * step_x + 2 * margin_x - padding_x
     height = rows * step_y + 2 * margin_y - padding_y
     img = Image.new('RGB', (width, height), border)
     # output glyphs
-    for ordinal, glyph in enumerate(glyphs):
+    for ordinal, glyph in enumerate(font.glyphs):
         if not glyph.width or not glyph.height:
             continue
         row, col = divmod(ordinal, columns)

--- a/monobit/raw.py
+++ b/monobit/raw.py
@@ -41,7 +41,7 @@ def save_aligned(outstream, font, encoding=None):
         raise ValueError(
             'This format only supports character-cell fonts.'
         )
-    for _, glyph in font.iter_ordinal(encoding=encoding):
+    for _, glyph in enumerate(font.glyphs):
         outstream.write(glyph.as_bytes())
 
 

--- a/monobit/winfnt.py
+++ b/monobit/winfnt.py
@@ -483,7 +483,7 @@ def create_fnt(font, version=0x200):
     # use only native encoding for now
     encoding = None
     # char table
-    ord_glyphs = [_glyph for _, _glyph in font.iter_ordinal(encoding=encoding)]
+    ord_glyphs = [_glyph for _, _glyph in enumerate(font.glyphs)]
     min_ord = 0
     max_ord = len(ord_glyphs) - 1
     # add the guaranteed-blank glyph


### PR DESCRIPTION
Fix few bugs while I was working to convert some BDF to PNG.

First, I got errors due no png saver was found (#2), but I just installed PIL (`pip install Pillow`) and it was fine.

Second, I got some errors about weird field missing or I was thinking so. After few minutes of digging in the code I found there might be bug that creates empty XLFD fields (to empty strings, if missing in the file) while loading BDF. It caused some property parsing problems, so I made it not generate empty strings for not existing fields and it loaded the font nicely.

Third the last, while saving it broke on some old code (`font.iter_ordinal`). I searched for it, and it seems the functionality it providing was replaced on some point with just `font.glyphs`, so made use of it in image saver (and raw and winfnt - note: I tested only image saver). 

Finally I had the file converted nicely - I include the file in ZIP if you want to test it with it.

[leggie-12.zip](https://github.com/robhagemans/monobit/files/6454303/leggie-12.zip)

