### PR TITLE
feat: Support gzip compressed files

### DIFF
--- a/tests/test_monobit.py
+++ b/tests/test_monobit.py
@@ -203,6 +203,15 @@ class TestMonobit(unittest.TestCase):
         font = pack[0]
         self.assertEqual(len(font.glyphs), 256)
 
+    def test_gzip(self):
+        """Test importing/exporting gzip compressed files"""
+        yaff_gz_file = self.temp_path / '4x6.yaff.gz'
+
+        monobit.save(self.fixed4x6, yaff_gz_file)
+        self.assertTrue(os.path.getsize(yaff_gz_file) > 0)
+
+        font = monobit.load(yaff_gz_file)
+        self.assertEqual(len(font.glyphs), 919)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* Adds support for directly importing/exporting gzip compressed font files.
* gzip compressed yaff/hex/bdf font files seem roughly 8 times smaller than uncompressed font files.