### PR TITLE
py: export as python byte array

### DIFF
--- a/monobit/formats/source.py
+++ b/monobit/formats/source.py
@@ -6,6 +6,7 @@ licence: https://opensource.org/licenses/MIT
 """
 
 import string
+import math
 
 from ..binary import ceildiv
 from ..storage import loaders, savers
@@ -241,13 +242,16 @@ def save_py(fonts, outstream, where=None):
     ascii_name = font.name.encode('ascii', 'ignore').decode('ascii')
     ascii_name = ''.join(_c if _c.isalnum() else '_' for _c in ascii_name)
     identifier = 'font_' + ascii_name
-    width, height = font.raster_size
-    bytesize = ceildiv(width, 8) * height
+    width, _ = font.raster_size
+    widthByteAligned = math.ceil(width/8)*8
     outstream.write(f'{identifier}')
     outstream.write(' = [\n')
     for glyph in font.glyphs:
         outstream.write('  ')
         for byte in glyph.as_bytes():
+            # glyphs are expanded right with 0 to full bytes, 
+            # we have to chop of the 0s again
+            byte = byte >> (widthByteAligned-width)
             outstream.write(f'0x{byte:02x}, ')
         outstream.write('\n')
     outstream.write(']\n')

--- a/tests/test_monobit.py
+++ b/tests/test_monobit.py
@@ -200,6 +200,12 @@ class TestFormats(BaseTester):
         monobit.save(self.fixed4x6, fnt_file)
         self.assertTrue(os.path.getsize(fnt_file) > 0)
 
+    def test_export_py(self):
+        """Test exporting c source files."""
+        fnt_file = self.temp_path  / '4x6.py'
+        monobit.save(self.fixed4x6, fnt_file)
+        self.assertTrue(os.path.getsize(fnt_file) > 0)
+
     def test_import_png(self):
         """Test importing image files."""
         font, *_ = monobit.load(self.font_path / '4x6.png', cell=(4, 6), numchars=919)


### PR DESCRIPTION
I added the the possibility to export python code.
It's a modified copy of the c export.

Unfortunately I did not manage to read the generated python code again. But I don't know if that's necessary.

```
ernst@Schamgar ~/Dropbox/Source/python/monobit
[632] : python3 convert.py c64-german.draw c64_german.py
INFO: Loading `c64-german.draw` on `.` as hexdraw
INFO: Saving `c64_german.py` on `.` as Python source.
ernst@Schamgar ~/Dropbox/Source/python/monobit
[635] : python3 convert.py --debug c64_german.py c64_german.c
DEBUG: Opening file `c64_german.py` for mode 'r'.
DEBUG: Exiting <Stream name='c64_german.py' mode='r'> with reference count 0.
DEBUG: Opening DirContainer container `.` for 'r'.
DEBUG: Opening file `c64_german.py` for mode 'r'.
INFO: Loading `c64_german.py` on `.` as Python source
DEBUG: Exiting <Stream name='c64_german.py' mode='r'> with reference count 0.
DEBUG: Exiting <DirContainer name='.' mode='r'> with reference count 0.
ERROR: load_py() missing 1 required keyword-only argument: 'identifier'
Traceback (most recent call last):
  File "/Users/ernst/Dropbox/Source/python/monobit/monobit/storage.py", line 63, in open_location
    with open_container(stream, mode, overwrite=overwrite) as container:
  File "/Users/ernst/Dropbox/Source/python/monobit/monobit/containers.py", line 45, in open_container
    container_type = _identify_container(file, mode, overwrite)
  File "/Users/ernst/Dropbox/Source/python/monobit/monobit/containers.py", line 65, in _identify_container
    raise ContainerFormatError('Expected container format, got non-container stream.')
monobit.containers.ContainerFormatError: Expected container format, got non-container stream.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/ernst/Dropbox/Source/python/monobit/convert.py", line 92, in <module>
    pack = monobit.load(infile, format=args.from_, **loader_args.pick(args))
  File "/Users/ernst/Dropbox/Source/python/monobit/monobit/storage.py", line 81, in load
    return _load_from_file(stream, container, format, **kwargs)
  File "/Users/ernst/Dropbox/Source/python/monobit/monobit/storage.py", line 90, in _load_from_file
    fonts = loader(instream, where, **kwargs)
  File "/Users/ernst/Dropbox/Source/python/monobit/monobit/scripting.py", line 35, in _scriptable_func
    result = func(*args, **kwargs)
TypeError: load_py() missing 1 required keyword-only argument: 'identifier'
ernst@Schamgar ~/Dropbox/Source/python/monobit

```