### PR TITLE
logging.basicConfig()

### DIFF
--- a/monobit/scripting.py
+++ b/monobit/scripting.py
@@ -328,7 +328,7 @@ def wrap_main(debug=False):
         loglevel = logging.DEBUG
     else:
         loglevel = logging.WARNING
-    logging.basicConfig(level=loglevel, format='%(levelname)s: %(message)s')
+    logging.basicConfig(level=loglevel, format='%(levelname)s: %(message)s', force=True)
     # run main script
     try:
         yield


### PR DESCRIPTION
`logging.basicConfig()` is ignored (unless `force=True`) if the logger is already configured.  `logging.error()`, `logging.info()`, etc, will auto-configure the logger, if it hasn't been configured.

So something like:
```
try:
    from uniseg.graphemecluster import grapheme_clusters
except ImportError:
    logging.warning(
        'Module `uniseg` not found. Grapheme clusters may not render correctly.'
    )
```
will auto-configure the logger and later attempts to configure it will be unsuccessful.