### PR TITLE
A couple issues I encountered generating Apple IIgs fonts:

### DIFF
--- a/monobit/formats/mac/nfnt.py
+++ b/monobit/formats/mac/nfnt.py
@@ -137,10 +137,16 @@ def loc_entry_struct(base):
 # Missing glyphs are represented by a word value of -1. The last word of this table is also -1,
 # representing the end.
 def wo_entry_struct(base):
-    return base.Struct(
-        offset='uint8',
-        width='uint8',
-    )
+    if base == be:
+        return base.Struct(
+            offset='uint8',
+            width='uint8',
+        )
+    else:
+        return base.Struct(
+            width='uint8',
+            offset='uint8',
+        )
 
 # glyph width table entry
 # > Glyph-width table. For every glyph in the font, this table contains a word
@@ -414,12 +420,13 @@ def _subset(font):
         labels = tuple(range(0, 128))
     else:
         font = font.label()
-        labels = tuple(Char(_c) for _c in charmaps['mac-roman'].mapping.values())
+        labels = tuple(Char(_c) for _i, _c in sorted(charmaps['mac-roman'].mapping.items()))
     subfont = font.subset(labels=labels)
     if not subfont.glyphs:
         raise FileFormatError('No suitable characters for NFNT font')
     glyphs = [*subfont.glyphs, font.get_default_glyph()]
     font = font.modify(glyphs, encoding=None)
+    font = font.label(codepoint_from='mac-roman', overwrite=True)
     return font
 
 


### PR DESCRIPTION
1. Apple IIgs uses an width/offset table rather than an offset/width table, due to the endian difference and treating a 16-bit value as a pair of 8-bit values.
2. The macroman character map isn't in order; specifically the characters from the _MAC_GRAPH_RANGE (0x11-0x15) are at the end instead of the beginning.  If any of those are present, the last_char (int(glyphs[-2].codepoint) will not be the largest codepoint and the generated font will most likely be empty.
3. If codepoints from the original encoding are retained, extended characters will be out of order in the generated font.

There might be better ways to handle these :)