### PR TITLE
add as_image_rgb() function for 24-bit color support

### DIFF
--- a/monobit/containers/__init__.py
+++ b/monobit/containers/__init__.py
@@ -14,5 +14,5 @@ from importlib.resources import files
 globals().update({
     Path(_file).stem: import_module('.' + Path(_file.name).stem, __package__)
     for _file in files(__name__).iterdir()
-    if not _file.name.startswith('_')
+    if not _file.name.startswith('_') and not _file.name.startswith('.')
 })

--- a/monobit/formats/__init__.py
+++ b/monobit/formats/__init__.py
@@ -14,5 +14,5 @@ from importlib.resources import files
 globals().update({
     Path(_file).stem: import_module('.' + Path(_file.name).stem, __package__)
     for _file in files(__name__).iterdir()
-    if not _file.name.startswith('_')
+    if not _file.name.startswith('_') and not _file.name.startswith('.')
 })

--- a/monobit/glyph.py
+++ b/monobit/glyph.py
@@ -531,9 +531,14 @@ class Glyph(HasProps):
         """Return flat tuple of user-specified foreground and background objects."""
         return self._pixels.as_vector(ink=ink, paper=paper)
 
-    def as_bits(self, ink=1, paper=0):
+    def as_bits(self, ink=255, paper=0):
         """Return flat bits as bytes string."""
         return self._pixels.as_bits(ink=ink, paper=paper)
+
+    def as_bits_rgb(self, ink=(255,255,255), paper=(0,0,0)):
+        """Return flat bits as bytes string."""
+        return self._pixels.as_bits_rgb(ink=ink, paper=paper)
+
 
     def as_byterows(self, *, align='left'):
         """Convert glyph to rows of bytes."""

--- a/monobit/glyphmap.py
+++ b/monobit/glyphmap.py
@@ -75,13 +75,12 @@ class GlyphMap:
         return canvas.stretch(self._scale_x, self._scale_y).turn(self._turns)
 
     def to_images(
-            self, *, paper, ink, border, invert_y=False,
+            self, *, paper=0, ink=255, border=0, invert_y=False,
             transparent=True
         ):
-        """Draw images based on shhets in glyph map."""
+        """Draw greyscale images based on sheets in glyph map."""
         if not Image:
             raise ImportError('Rendering to image requires PIL module.')
-        paper, ink, border = 0, 255, 32
         last, min_x, min_y, max_x, max_y = self.get_bounds()
         # no +1 as bounds are inclusive
         width, height = max_x - min_x, max_y - min_y
@@ -110,7 +109,7 @@ class GlyphMap:
 
     def as_image(
             self, *,
-            ink=(255, 255, 255), paper=(0, 0, 0), border=(0, 0, 0),
+            ink=255, paper=0, border=0,
             sheet=0,
         ):
         """Convert glyph map to image."""

--- a/monobit/raster.py
+++ b/monobit/raster.py
@@ -232,13 +232,23 @@ class Raster:
             for _c in ''.join(self._pixels)
         )
 
-    def as_bits(self, ink=1, paper=0):
+    def as_bits(self, ink=255, paper=0):
         """Return flat bits as bytes string."""
         return (
             ''.join(self._pixels).encode('latin-1')
             .replace(self._1.encode('latin-1'), bytes((ink,)))
             .replace(self._0.encode('latin-1'), bytes((paper,)))
         )
+
+    def as_bits_rgb(self, ink=(255, 255, 255), paper=(0, 0, 0)):
+        """Return flat bits as bytes string."""
+        return [
+            tuple(pixel.encode('latin-1')
+            .replace(self._1.encode('latin-1'), bytes(ink))
+            .replace(self._0.encode('latin-1'), bytes(paper)))
+            for pixel_row in self._pixels
+            for pixel in pixel_row
+        ]
 
 
     @classmethod


### PR DESCRIPTION
Not sure if you are interested, feel free to ignore.

I needed this function to be able to transform ansi art text into images with color, like this one generated with topaz font,

![image](https://github.com/robhagemans/monobit/assets/972584/4159da9f-7273-4291-bf2e-c07effb13b9d)

it builds on #31 so this PR will reduce in size if that is merged first. #31 is needed to fix the related incorrect function signatures

