### PR TITLE
Fix StrokePath.draw() returning Canvas instead of Raster

### DIFF
--- a/monobit/core/vector.py
+++ b/monobit/core/vector.py
@@ -108,7 +108,7 @@ class StrokePath:
     def draw(self):
         """Draw the path."""
         if not self._path:
-            return Canvas.blank(0, 0)
+            return Canvas.blank(0, 0).as_raster()
         canvas = Canvas.blank(
             self.bounds.right - self.bounds.left,
             self.bounds.top - self.bounds.bottom,


### PR DESCRIPTION
Hello! `StrokePath.draw()` has a codepath that returns a `Canvas` instead of a `Raster`, leading to a crash. It looks like this was introduced in 07abf6ebc6af3c12f326bc4b2a8cd6b9f7be9ea2

Adding the missing `.as_raster()` fixes it. My test case is `banner.py` with Microsoft's "Script" proportional vector font from 1985 (SCRIPT.FON): https://downloads.scummvm.org/frs/demos/hugo/hugo1-dos-1.1-demo-en.zip

Thanks for supporting ancient Windows formats; it's a big help!