### PR TITLE
Improved BeOS font reader

### DIFF
--- a/monobit/core/glyph.py
+++ b/monobit/core/glyph.py
@@ -973,6 +973,10 @@ class Glyph(HasProps):
         """Reverse video."""
         return self.modify(self._pixels.invert())
 
+    def rescale_ink(self, new_level: int):
+        """Map ink values to the target level"""
+        return self.modify(self._pixels.rescale_ink(new_level))
+
     def roll(self, down:int=0, right:int=0):
         """
         Cycle rows and/or columns in raster.

--- a/monobit/core/glyph.py
+++ b/monobit/core/glyph.py
@@ -483,14 +483,14 @@ class Glyph(HasProps):
             cls, byteseq, width, height=NOT_SET,
             *, align='left', order='row-major', stride=NOT_SET,
             byte_swap=0, bit_order='big', bits_per_pixel=1,
-            **kwargs
+            ink_levels:int|None = None, **kwargs
         ):
         """Create glyph from bytes/bytearray/int sequence."""
         pixels = Raster.from_bytes(
             byteseq, width, height,
             align=align, stride=stride, order=order,
             byte_swap=byte_swap, bit_order=bit_order,
-            bits_per_pixel=bits_per_pixel,
+            bits_per_pixel=bits_per_pixel, ink_levels=ink_levels
         )
         return cls(pixels, **kwargs)
 
@@ -499,14 +499,14 @@ class Glyph(HasProps):
             cls, byteseq, width, height=NOT_SET,
             *, align='left', order='row-major', stride=NOT_SET,
             byte_swap=0, bit_order='big', bits_per_pixel=1,
-            **kwargs
+            ink_levels:int|None = None, **kwargs
         ):
         """Create glyph from hex string."""
         pixels = Raster.from_hex(
             byteseq, width, height,
             align=align, stride=stride, order=order,
             byte_swap=byte_swap, bit_order=bit_order,
-            bits_per_pixel=bits_per_pixel,
+            bits_per_pixel=bits_per_pixel, ink_levels=ink_levels
         )
         return cls(pixels, **kwargs)
 
@@ -567,7 +567,7 @@ class Glyph(HasProps):
 
     def as_bytes(
             self, *, align='left', stride=NOT_SET, byte_swap=0,
-            bit_order='big', bits_per_pixel=1,
+            bit_order='big', bits_per_pixel=1, ink_levels:int|None = None
         ):
         """
         Convert raster to flat bytes.
@@ -581,6 +581,7 @@ class Glyph(HasProps):
         return self._pixels.as_bytes(
             align=align, stride=stride, byte_swap=byte_swap,
             bit_order=bit_order, bits_per_pixel=bits_per_pixel,
+            ink_levels=ink_levels
         )
 
     def as_hex(self, **kwargs):

--- a/monobit/core/raster.py
+++ b/monobit/core/raster.py
@@ -4,12 +4,15 @@ monobit.core.raster - bitmap raster
 (c) 2019--2026 Rob Hagemans
 licence: https://opensource.org/licenses/MIT
 """
+from __future__ import annotations
 
 import logging
 import string
 from itertools import zip_longest
 from collections import deque
 from functools import cache
+import types
+from typing import Tuple
 
 from monobit.base.binary import (
     ceildiv, reverse_by_group, bytes_to_pixels,
@@ -27,6 +30,13 @@ def get_inklevels(n_levels):
     if n_levels <= 256:
         return _INKLEVELS256[:n_levels]
     raise ValueError('More than 256 ink levels not supported.')
+
+def _map_ink_level(current_level: str, target_level:int) -> tuple[str, dict[int,int]]:
+    c_lvl = len(current_level)
+    # TODO: this probably doesn't work with `invert`
+    dest = get_inklevels(target_level)
+    translated = ''.join(dest[round(_i * (target_level-1) / (c_lvl-1))] for _i in range(c_lvl))
+    return dest, str.maketrans(current_level, translated)
 
 
 # turn function for Raster, Glyph and Font
@@ -71,7 +81,7 @@ def shear_shift(y, xpitch, ypitch, modulo):
 class Raster:
     """Bit matrix."""
 
-    def __init__(self, pixels=(), *, width=NOT_SET, inklevels=NOT_SET):
+    def __init__(self, pixels=(), *, width: int | None | types.EllipsisType = NOT_SET, inklevels: str | None | types.EllipsisType =NOT_SET):
         """Create raster from tuple of tuples of string."""
         if isinstance(pixels, type(self)):
             width = pixels._width
@@ -80,17 +90,19 @@ class Raster:
         else:
             if pixels:
                 width = len(pixels[0])
-            elif width is NOT_SET:
+            elif width is NOT_SET or isinstance(width, types.EllipsisType):
                 width = 0
-            if inklevels is NOT_SET:
-                inklevels = get_inklevels(2)
-        self._pixels = pixels
-        self._width = width
-        self._inklevels = inklevels
+        if inklevels is None or inklevels is NOT_SET or isinstance(inklevels, types.EllipsisType):
+            inklevels = get_inklevels(2)
         if set(inklevels) < set(''.join(pixels)):
             raise ValueError(f"{set(inklevels)} >= {set(''.join(pixels))} fails")
+        self._pixels = pixels
+        self._width: int | None = width
+        self._inklevels: str = inklevels
+        """
+        The string representing the ink levels
+        """
         self._paper = self._inklevels[0]
-        self._levels = len(self._inklevels)
         # check pixel matrix types
         if (
                 not isinstance(self._pixels, tuple)
@@ -103,6 +115,10 @@ class Raster:
             raise ValueError(
                 f"All rows in raster must be of the same width: {repr(self)}"
             )
+
+    @property
+    def _levels(self) -> int:
+        return len(self._inklevels)
 
     def __bool__(self):
         """Raster is not empty."""
@@ -243,7 +259,7 @@ class Raster:
             cls, byteseq, width=NOT_SET, height=NOT_SET,
             *, align='left', order='row-major', stride=NOT_SET,
             byte_swap=0, bit_order='big', bits_per_pixel=1,
-            **kwargs
+            ink_levels: int| None, **kwargs
         ):
         """
         Create raster from bytes/bytearray/int sequence.
@@ -803,10 +819,15 @@ class Raster:
         )
         return type(self)(combined, inklevels=self._inklevels)
 
-    def invert(self):
+    def invert(self) -> Raster:
         """Reverse video."""
         return type(self)(self._pixels, inklevels=self._inklevels[::-1])
-
+                             
+    def rescale_ink(self, new_level: int) -> Raster:
+        """Map ink values to the target level"""
+        dest_str, translator = _map_ink_level(self._inklevels, new_level)
+        return type(self)(tuple(_row.translate(translator) for _row in self._pixels), inklevels=dest_str)
+    
     def smear(self, *, left:int=0, right:int=0, up:int=0, down:int=0):
         """
         Repeat inked pixels.

--- a/monobit/core/raster.py
+++ b/monobit/core/raster.py
@@ -94,7 +94,7 @@ class Raster:
                 width = 0
         if inklevels is None or inklevels is NOT_SET or isinstance(inklevels, types.EllipsisType):
             inklevels = get_inklevels(2)
-        if set(inklevels) < set(''.join(pixels)):
+        if set(''.join(pixels)) - set(inklevels):
             raise ValueError(f"{set(inklevels)} >= {set(''.join(pixels))} fails")
         self._pixels = pixels
         self._width: int | None = width
@@ -259,7 +259,7 @@ class Raster:
             cls, byteseq, width=NOT_SET, height=NOT_SET,
             *, align='left', order='row-major', stride=NOT_SET,
             byte_swap=0, bit_order='big', bits_per_pixel=1,
-            ink_levels: int| None, **kwargs
+            ink_levels: int| None = None, **kwargs
         ):
         """
         Create raster from bytes/bytearray/int sequence.
@@ -272,6 +272,7 @@ class Raster:
         byte_swap: swap byte order in units of n bytes, 0 (default) for no swap
         bit_order: per-byte bit endianness; 'little' for lsb left, 'big' (default) for msb left
         bits_per_pixel: bit depth; must be 1, 2, 4 or 8 (default: 1)
+        ink_levels: number of ink_levels if different from bits per pixel (default: 2**bits_per_pixel)
         """
         if all(_arg is NOT_SET for _arg in (width, height, stride)):
             raise ValueError(
@@ -279,10 +280,11 @@ class Raster:
             )
         pixels_per_byte = 8 // bits_per_pixel
         levels = 2**bits_per_pixel
+        ink_levels_computed: int = levels if ink_levels is None else ink_levels
         if width == 0 or height == 0:
             if height is NOT_SET:
                 height = 0
-            return cls.blank(width, height, levels=levels)
+            return cls.blank(width, height, levels=ink_levels_computed)
         if stride is not NOT_SET:
             if width is NOT_SET:
                 width = stride
@@ -311,7 +313,7 @@ class Raster:
             )
         # convert bytes to pixels
         bitseq = bytes_to_pixels(byteseq, levels)
-        inklevels = get_inklevels(levels)
+        inklevels = get_inklevels(ink_levels_computed)
         # per-byte bit swap.
         if bit_order == 'little':
             bitseq = reverse_by_group(bitseq, group_size=pixels_per_byte)
@@ -356,7 +358,7 @@ class Raster:
     def as_bytes(
             self, *,
             align='left', stride=NOT_SET, byte_swap=0, bit_order='big',
-            bits_per_pixel=1,
+            bits_per_pixel=1, ink_levels: int | None = None
         ):
         """
         Convert raster to flat bytes.
@@ -366,7 +368,12 @@ class Raster:
         byte_swap: swap byte order in units of n bytes, 0 (default) for no swap
         bit_order: per-byte bit endianness; 'little' for lsb left, 'big' (default) for msb left
         bits_per_pixel: bit depth; must be higher than or equal to intrinsic bit depth (default: 1).
+        ink_levels: number of ink_levels if different from bits per pixel (default: 2**bits_per_pixel)
         """
+        if ink_levels is not None and ink_levels != self._levels:
+            raise ValueError(
+                f'Raster has {self._levels} ink levels, not {ink_levels}.'
+            )
         if not self.height or not self.width:
             return b''
         raster = self
@@ -382,14 +389,17 @@ class Raster:
         elif bits_per_pixel < intr_bpp:
             raise ValueError(f'Requires at least {intr_bpp} bits per pixel.')
         if bits_per_pixel > intr_bpp:
-            # must be a multiple - choice of 1, 2, 4, 8
-            factor = bits_per_pixel // intr_bpp
-            # widen each pixel to the expected number of bits
-            # e.g 1->2bpp 0 -> 00 1 -> 11
-            #     4->8bpp 5 -> 55 A -> AA
-            raster = raster.stretch(factor=(factor, 1))
+            if ink_levels is None:
+                # must be a multiple - choice of 1, 2, 4, 8
+                factor = bits_per_pixel // intr_bpp
+                # widen each pixel to the expected number of bits
+                # e.g 1->2bpp 0 -> 00 1 -> 11
+                #     4->8bpp 5 -> 55 A -> AA
+                raster = raster.stretch(factor=(factor, 1))
+            else:
+                raster = type(raster)(raster._pixels, inklevels=get_inklevels(2**bits_per_pixel),)
         if align == 'bit':
-            inklevels = get_inklevels(self._levels)
+            inklevels = get_inklevels(raster._levels)
             bits = ''.join(
                 ''.join(_row)
                 for _row in raster.as_matrix(inklevels=inklevels)

--- a/monobit/core/raster.py
+++ b/monobit/core/raster.py
@@ -94,8 +94,11 @@ class Raster:
                 width = 0
         if inklevels is None or inklevels is NOT_SET or isinstance(inklevels, types.EllipsisType):
             inklevels = get_inklevels(2)
-        if set(''.join(pixels)) - set(inklevels):
-            raise ValueError(f"{set(inklevels)} >= {set(''.join(pixels))} fails")
+        out_of_range = set(''.join(pixels)) - set(inklevels)
+        if out_of_range:
+            raise ValueError(
+                f'Pixel values {out_of_range} not in ink levels {set(inklevels)}.'
+            )
         self._pixels = pixels
         self._width: int | None = width
         self._inklevels: str = inklevels

--- a/monobit/storage/fontformats/beos.py
+++ b/monobit/storage/fontformats/beos.py
@@ -8,97 +8,147 @@ licence: https://opensource.org/licenses/MIT
 import logging
 from itertools import accumulate
 
+from monobit.base.basetypes import FileFormatError, UnsupportedError
 from monobit.base.binary import ceildiv
 from monobit.base.struct import big_endian as be
-from monobit.storage import loaders, savers
 from monobit.core import Font, Glyph
+from monobit.storage import loaders, savers
+from monobit.storage.streams import Stream
+from monobit.storage.utils.limitations import ensure_levels, ensure_single
 
-from monobit.storage.utils.limitations import ensure_single, ensure_levels
-
+logger = logging.getLogger(__name__)
 
 # http://www.eonet.ne.jp/~hirotsu/bin/bmf_format.txt
 
 _HEADER = be.Struct(
     mark='4s',
-    # > total size
+    # total size of the file
     size='uint32',
     # > font-family-name size (not including the trailing null)
     ffnSize='uint16',
     # > font-style-name size (not including the trailing null)
     fsnSize='uint16',
-    padding_0='10s',
-    # > The number of characters that can be stored in the location-table -1
-    ltMax='uint16',
+    # rotation and shear angles in radians, 0.0 for upright
+    rotation='float',
+    shear='float',
+    # location-table hash mask; must be a power of two minus one
+    hmask='uint32',
     # > font-point (Bitmap fonts are enabled at this point number)
     point='uint16',
-    # > 0x0300 (unknown)
-    unknown_768='uint16',
-    # unknown and differs per font; ProFont has it all null so that is valid?
-    unknown='8s',
+    # pixel format: 1 = B/W (RLE), 2 = TV scale, 3 = grayscale (4-bit packed)
+    bpp='uint8',
+    version='uint8',
+    # uninitialised memory in fonts written by BeOS
+    reserved='8s',
 )
 
+_FC_BLACK_AND_WHITE = 1
+_FC_TV_SCALE = 2
+_FC_GRAY_SCALE = 3
+
 _LOCATION_ENTRY = be.Struct(
-    pointer='uint32',
-    code='uint16',
-    reserved='uint16',
+    offset='uint32',
+    # utf-16: [char or high surrogate, low surrogate or 0]
+    code_0='uint16',
+    code_1='uint16',
 )
 
 _GLYPH_DATA = be.Struct(
-    unknown_0x4996b438 = 'uint32',
-    unknown_0x4996b440 = 'uint32',
+    # ink edges of the scalable glyph, in em units;
+    # 1234567.0 in edge_left means 'edges not computed'
+    edge_left='float',
+    edge_right='float',
+    # bitmap bounding box relative to the baseline origin, y down
     left='int16',
     top='int16',
     right='int16',
     bottom='int16',
-    width='float',
-    maybe_height='float',
+    # advance vector in (fractional) pixels
+    x_escape='float',
+    y_escape='float',
 )
 
+_EDGE_LEFT_NOT_COMPUTED = 1234567.0
+_EDGE_RIGHT_NOT_COMPUTED = 1234568.0
+
 _BEOS_MAGIC = b'|Be;'
+
+def _char_from_codes(code_0: int, code_1: int) -> str:
+    """Decode a location-entry utf-16 code unit pair to a character."""
+    if 0xd800 <= code_0 < 0xdc00 and 0xdc00 <= code_1 < 0xe000:
+        return chr(
+            0x10000 + ((code_0 - 0xd800) << 10) + (code_1 - 0xdc00)
+        )
+    return chr(code_0)
 
 
 @loaders.register(
     name='beos',
     magic=(_BEOS_MAGIC,)
 )
-def load_beos(instream):
+def load_beos(instream: Stream):
     """Load font from Be Bitmap Font file."""
     header = _HEADER.read_from(instream)
+    if header.version != 0:
+        raise FileFormatError( f'Unknown Be Bitmap Font version {header.version}.' )
+    if header.bpp != _FC_GRAY_SCALE:
+        raise UnsupportedError('Only grayscale Be Bitmap Fonts are supported.')
+    if header.rotation != 0 or header.shear != 0:
+        logger.warning('Nonzero rotation or shear angles are ignored.')
+    if header.hmask & (header.hmask + 1) or header.hmask < 3:
+        # BeOS rejects such files; older monobit versions wrote them
+        logger.warning('Location-table mask is not a power of two minus one')
     familyName = instream.read(header.ffnSize+1)[:-1].decode('latin-1')
     styleName = instream.read(header.fsnSize+1)[:-1].decode('latin-1')
-    logging.debug('header: %s', header)
-    logging.debug('family: %s', familyName)
-    logging.debug('style: %s', styleName)
+    logger.debug('family: %s', familyName)
+    logger.debug('style: %s', styleName)
+
+    table_size = _LOCATION_ENTRY.size * (header.hmask+1)
+    table_bytes = instream.read(table_size)
+    if len(table_bytes) != table_size:
+        raise FileFormatError('Location table extends beyond end of file.')
+    
     # hash table of pointers to glyphs, hashed by unicode codepoint
-    location_table = (_LOCATION_ENTRY * (header.ltMax+1)).read_from(instream)
-    location_dict = {_e.pointer: _e.code for _e in location_table}
+    location_table = (_LOCATION_ENTRY * (header.hmask+1)).from_bytes(table_bytes)
+    location_dict = {
+        _e.offset: _char_from_codes(_e.code_0, _e.code_1)
+        for _e in location_table
+        # the offset is read as signed by BeOS; empty slots hold -1
+        if 0 < _e.offset < 0x80000000
+    }
+
     glyphs = []
     while instream.tell() < header.size:
         pointer = instream.tell()
-        code = location_dict.get(pointer, None)
         glyph_data = _GLYPH_DATA.read_from(instream)
+        # TODO: validate glyph geometry?
         # bitmap dimensions
         width = glyph_data.right - glyph_data.left + 1
         height = glyph_data.bottom - glyph_data.top + 1
-        # 4 bits per pixel
-        bytewidth = ceildiv(width * 4, 8)
-        glyph_bytes = instream.read(height*bytewidth)
+        bitmap_size = ceildiv(width * 4, 8) * height
+        glyph_bytes = instream.read(bitmap_size)
+        # TODO sanity check bitmap_size = glyph_bites
+        # TODO sanity check legacy_ink
         glyphs.append(
             Glyph.from_bytes(
                 glyph_bytes, width=width, height=height, bits_per_pixel=4,
-                char=chr(code) if code is not None else code,
-                right_bearing=round(glyph_data.width)-width-glyph_data.left,
+                char=location_dict.get(pointer, None),
+                right_bearing=(int(glyph_data.x_escape + .5) - width - glyph_data.left),
                 left_bearing=glyph_data.left,
                 shift_up=-1-glyph_data.bottom,
-                scalable_width=glyph_data.width,
+                scalable_width=glyph_data.x_escape,
             )
         )
+    ## TODO: sanity check overhang
+
+    # TODO: detect legacy_ink?
     return Font(
         glyphs,
         encoding='unicode',
         family=familyName,
         subfamily=styleName,
         point_size=header.point,
+        # TODO: verify ppem/dpi=72
     )
 
 

--- a/monobit/storage/fontformats/beos.py
+++ b/monobit/storage/fontformats/beos.py
@@ -102,26 +102,11 @@ def _location_hash(code_0: int, code_1: int, hmask: int) -> int:
     """Location-table hash function"""
     return (((code_0 << 3) ^ (code_0 >> 2)) + code_1) & hmask
 
-def _nibble_translation(mapping: tuple[int, ...]) -> bytes:
-    """Bytes translation table applying a mapping to both nibbles."""
-    return bytes(
-        (mapping[_byte >> 4] << 4) | mapping[_byte & 0xf]
-        for _byte in range(256)
-    )
-
-_INK_LOAD = _nibble_translation(
-    tuple(min(15, round(_v * 15 / 7)) for _v in range(16))
-)
-_INK_SAVE = _nibble_translation(
-    tuple(round(_v * 7 / 15) for _v in range(16))
-)
-"""4-bit quant"""
-
 @loaders.register(
     name='beos',
     magic=(_BEOS_MAGIC,)
 )
-def load_beos(instream: Stream):
+def load_beos(instream: Stream, expand_ink: bool = True):
     """Load font from Be Bitmap Font file."""
     header = _HEADER.read_from(instream)
     if header.version != 0:
@@ -162,18 +147,20 @@ def load_beos(instream: Stream):
         glyph_bytes = instream.read(bitmap_size)
         # TODO sanity check bitmap_size = glyph_bites
         # TODO sanity check legacy_ink - older monobit didn't scale
-        glyph_bytes = glyph_bytes.translate(_INK_LOAD)
 
-        glyphs.append(
-            Glyph.from_bytes(
-                glyph_bytes, width=width, height=height, bits_per_pixel=4,
-                char=location_dict.get(pointer, None),
-                right_bearing=(int(glyph_data.x_escape + .5) - width - glyph_data.left),
-                left_bearing=glyph_data.left,
-                shift_up=-1-glyph_data.bottom,
-                scalable_width=glyph_data.x_escape,
-            )
-        )
+        glyph = Glyph.from_bytes(
+                        glyph_bytes, width=width, height=height, bits_per_pixel=4,
+                        char=location_dict.get(pointer, None),
+                        right_bearing=(int(glyph_data.x_escape + .5) - width - glyph_data.left),
+                        left_bearing=glyph_data.left,
+                        shift_up=-1-glyph_data.bottom,
+                        scalable_width=glyph_data.x_escape,
+                        ink_levels=8
+                    )
+        #useful for conversion, unneccesary for native
+        if expand_ink:
+            glyph = glyph.rescale_ink(16)
+        glyphs.append(glyph)
     ## TODO: sanity check overhang
 
     # TODO: detect legacy_ink?
@@ -234,7 +221,7 @@ def save_beos(fonts, outstream):
         _HEADER.size + header.ffnSize + 1 + header.fsnSize + 1
         + _LOCATION_ENTRY.size * count
     )
-    glyph_bytes = tuple(_g.as_bytes(bits_per_pixel=4).translate(_INK_SAVE) for _g in glyphs)
+    glyph_bytes = tuple(_g.rescale_ink(8).as_bytes(bits_per_pixel=4, ink_levels=8) for _g in glyphs)
     offsets = accumulate(
         (len(_g) + len(_s) for _g, _s in zip(glyph_data, glyph_bytes)),
         initial=strike_offset,

--- a/monobit/storage/fontformats/beos.py
+++ b/monobit/storage/fontformats/beos.py
@@ -130,9 +130,7 @@ def load_beos(instream: Stream):
         raise UnsupportedError('Only grayscale Be Bitmap Fonts are supported.')
     if header.rotation != 0 or header.shear != 0:
         logger.warning('Nonzero rotation or shear angles are ignored.')
-    if header.hmask & (header.hmask + 1) or header.hmask < 3:
-        # BeOS rejects such files; older monobit versions wrote them
-        logger.warning('Location-table mask is not a power of two minus one')
+    # TODO: sanity check hmask
     familyName = instream.read(header.ffnSize+1)[:-1].decode('latin-1')
     styleName = instream.read(header.fsnSize+1)[:-1].decode('latin-1')
     logger.debug('family: %s', familyName)

--- a/monobit/storage/fontformats/beos.py
+++ b/monobit/storage/fontformats/beos.py
@@ -107,7 +107,11 @@ def _location_hash(code_0: int, code_1: int, hmask: int) -> int:
     magic=(_BEOS_MAGIC,)
 )
 def load_beos(instream: Stream, expand_ink: bool = True):
-    """Load font from Be Bitmap Font file."""
+    """
+    Load font from Be Bitmap Font file.
+
+    expand_ink: rescale BeOS's 8 ink levels to the full 16-level range (default: True)
+    """
     header = _HEADER.read_from(instream)
     if header.version != 0:
         raise FileFormatError( f'Unknown Be Bitmap Font version {header.version}.' )

--- a/monobit/storage/fontformats/beos.py
+++ b/monobit/storage/fontformats/beos.py
@@ -81,6 +81,40 @@ def _char_from_codes(code_0: int, code_1: int) -> str:
         )
     return chr(code_0)
 
+def _location_table_size(n_glyphs: int) -> int:
+    """
+    the smallest power of two that holds the glyphs with 25% headroom, minimum 4. 
+    BeOS rejects the file otherwise.
+    """
+    needed = ceildiv(n_glyphs * 5, 4)
+    return max(4, 1 << (needed - 1).bit_length())
+
+def _codes_from_char(char: str) -> tuple[int, int]:
+    """Encode a character as a location-entry utf-16 code unit pair."""
+    codepoint = ord(char)
+    if codepoint > 0xffff:
+        codepoint -= 0x10000
+        return 0xd800 + (codepoint >> 10), 0xdc00 + (codepoint & 0x3ff)
+    return codepoint, 0
+
+def _location_hash(code_0: int, code_1: int, hmask: int) -> int:
+    """Location-table hash function"""
+    return (((code_0 << 3) ^ (code_0 >> 2)) + code_1) & hmask
+
+def _nibble_translation(mapping: tuple[int, ...]) -> bytes:
+    """Bytes translation table applying a mapping to both nibbles."""
+    return bytes(
+        (mapping[_byte >> 4] << 4) | mapping[_byte & 0xf]
+        for _byte in range(256)
+    )
+
+_INK_LOAD = _nibble_translation(
+    tuple(min(15, round(_v * 15 / 7)) for _v in range(16))
+)
+_INK_SAVE = _nibble_translation(
+    tuple(round(_v * 7 / 15) for _v in range(16))
+)
+"""4-bit quant"""
 
 @loaders.register(
     name='beos',
@@ -128,7 +162,9 @@ def load_beos(instream: Stream):
         bitmap_size = ceildiv(width * 4, 8) * height
         glyph_bytes = instream.read(bitmap_size)
         # TODO sanity check bitmap_size = glyph_bites
-        # TODO sanity check legacy_ink
+        # TODO sanity check legacy_ink - older monobit didn't scale
+        glyph_bytes = glyph_bytes.translate(_INK_LOAD)
+
         glyphs.append(
             Glyph.from_bytes(
                 glyph_bytes, width=width, height=height, bits_per_pixel=4,
@@ -160,46 +196,50 @@ def save_beos(fonts, outstream):
     font = ensure_levels(font, 16)
     font = font.label()
     # drop multi-codepoint sequences and unlabelled glyphs
-    glyphs = tuple(_g for _g in font.glyphs if len(_g.char) == 1)
+    glyphs = tuple(_g for _g in font.glyphs if _g.char and len(_g.char) == 1)
     # create header
-    style_name = font.name[len(font.family):].strip()
+    style_name = font.subfamily or font.name[len(font.family):].strip()
+    family_name = font.family
+    # TODO: sanity check length
+    count = _location_table_size(len(glyphs))
     header = _HEADER(
         mark=_BEOS_MAGIC,
         # size='uint32',
-        ffnSize=len(font.family),
+        ffnSize=len(family_name),
         fsnSize=len(style_name),
-        # ltMax is an assumption reproducing the value in my sample font
-        ltMax = 2*(len(glyphs)-1)-1,
+        hmask=count-1,
         point=font.point_size,
-        unknown_768=0x300,
+        bpp=_FC_GRAY_SCALE,
+        version=0,
     )
     # create glyph table
     glyph_data = tuple(
         bytes(_GLYPH_DATA(
-            unknown_0x4996b438 = 0x4996b438,
-            unknown_0x4996b440 = 0x4996b440,
+            edge_left=_EDGE_LEFT_NOT_COMPUTED,
+            edge_right=_EDGE_RIGHT_NOT_COMPUTED,
             left=_g.left_bearing,
             top=(-1-_g.shift_up) -_g.height + 1,
             right=_g.width + _g.left_bearing - 1,
             bottom=-1-_g.shift_up,
-            width=_g.scalable_width,
-            # maybe_height='float',
+            x_escape=_g.scalable_width,
+            # y_escape='float',
         ))
         for _g in glyphs
     )
     strike_offset = (
         _HEADER.size + header.ffnSize + 1 + header.fsnSize + 1
-        + _LOCATION_ENTRY.size * (header.ltMax+1)
+        + _LOCATION_ENTRY.size * count
     )
-    glyph_bytes = tuple(_g.as_bytes(bits_per_pixel=4) for _g in glyphs)
+    glyph_bytes = tuple(_g.as_bytes(bits_per_pixel=4).translate(_INK_SAVE) for _g in glyphs)
     offsets = accumulate(
         (len(_g) + len(_s) for _g, _s in zip(glyph_data, glyph_bytes)),
         initial=strike_offset,
     )
     # create location entries
+    codes = tuple(_codes_from_char(_g.char) for _g in glyphs)
     loc_entries = tuple(
-        _LOCATION_ENTRY(pointer=_offs, code=ord(_g.char))
-        for _g, _offs in zip(glyphs, offsets)
+        _LOCATION_ENTRY(offset=_offs, code_0=_c0, code_1=_c1)
+        for (_c0, _c1), _offs in zip(codes, offsets)
     )
     strike = b''.join(
         b''.join((_data, _bytes))
@@ -211,19 +251,17 @@ def save_beos(fonts, outstream):
         ((ord(_g.char)>>2) ^ (ord(_g.char)<<3)) & header.ltMax
         for _g in glyphs
     )
-    location_table = [None] * (header.ltMax+1)
+    location_table = [None] * count
     for entry, hash in zip(loc_entries, hashes):
         while location_table[hash] is not None:
-            hash += 1
-            if hash > header.ltMax:
-                hash = 0
+            hash = (hash + 1) & header.hmask
         location_table[hash] = entry
-    location_table = (_LOCATION_ENTRY * (header.ltMax+1))(*(
-        _entry if _entry else _LOCATION_ENTRY(pointer=0xffffffff)
+    location_table = (_LOCATION_ENTRY * count)(*(
+        _entry if _entry else _LOCATION_ENTRY(offset=0xffffffff)
         for _entry in location_table
     ))
     outstream.write(bytes(header))
-    outstream.write(font.family.encode('latin-1', 'replace')+ b'\0')
+    outstream.write(family_name.encode('latin-1', 'replace')+ b'\0')
     outstream.write(style_name.encode('latin-1', 'replace')+ b'\0')
     outstream.write(bytes(location_table))
     outstream.write(bytes(strike))

--- a/monobit/storage/fontformats/beos.py
+++ b/monobit/storage/fontformats/beos.py
@@ -65,6 +65,7 @@ _GLYPH_DATA = be.Struct(
     bottom='int16',
     # advance vector in (fractional) pixels
     x_escape='float',
+    # `x_escape` is the LINEAR (outline) escapement stored in the file
     y_escape='float',
 )
 
@@ -192,6 +193,11 @@ def load_beos(instream: Stream):
 def save_beos(fonts, outstream):
     """Save font to BeOS file."""
     font = ensure_single(fonts)
+    if font.levels > 8:
+        logger.warning(
+            'BeOS stores 8 ink levels; %d-level ink will be quantised.',
+            font.levels,
+        )
     # 4 bits per pixel
     font = ensure_levels(font, 16)
     font = font.label()
@@ -248,8 +254,8 @@ def save_beos(fonts, outstream):
     header.size = strike_offset + len(strike)
     # create hash table
     hashes = (
-        ((ord(_g.char)>>2) ^ (ord(_g.char)<<3)) & header.ltMax
-        for _g in glyphs
+        _location_hash(_c0, _c1, header.hmask)
+        for _c0, _c1 in codes
     )
     location_table = [None] * count
     for entry, hash in zip(loc_entries, hashes):

--- a/tests/test_greyscale.py
+++ b/tests/test_greyscale.py
@@ -2,14 +2,14 @@
 monobit test suite
 greyscale feature tests
 """
+from __future__ import annotations
 
-import os
-import io
 import unittest
 
 import monobit
-from .base import BaseTester, get_stringio, assert_text_eq
+from monobit.base.basetypes import RGB
 
+from .base import BaseTester, assert_text_eq
 
 
 class TestGreyscale(BaseTester):
@@ -30,7 +30,7 @@ class TestGreyscale(BaseTester):
 # .........
 # """
 
-    def _render_greyscale(self, format, *, char=False, load_kwargs=(), save_kwargs=()):
+    def _render_greyscale(self, format, *, char=False, load_kwargs=(), save_kwargs=(), expected: str | None = None):
         font1, *_ = monobit.load(self.font_path / 'konatu-ascii.yaff')
         monobit.save(
             font1, self.temp_path / f'konatu-ascii.{format}',
@@ -44,8 +44,8 @@ class TestGreyscale(BaseTester):
             text = 'te'
         else:
             text = b'te'
-        rendered_text = monobit.render_text(font2, text).as_shades(border=(0,0,0))
-        assert_text_eq(ascii(rendered_text), self.sampletext)
+        rendered_text = monobit.render_text(font2, text).as_shades(border=RGB(0,0,0))
+        assert_text_eq(ascii(rendered_text), expected or self.sampletext)
 
     def test_yaff_greyscale(self):
         self._render_greyscale('yaff')
@@ -57,7 +57,9 @@ class TestGreyscale(BaseTester):
         self._render_greyscale('bdf')
 
     def test_beos_greyscale(self):
-        self._render_greyscale('beos')
+        # BeOS has 8 grey levels, not 16-level font - quantize first
+        expected = self.sampletext.replace('38;2;17;17;17m', '38;2;0;0;0m').replace('38;2;119;119;119m', '38;2;102;102;102m')
+        self._render_greyscale('beos', expected=expected)
 
     def test_nfnt_greyscale(self):
         self._render_greyscale('nfnt')

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1518,14 +1518,14 @@ class TestImport(BaseTester):
         font, *_ = monobit.load(file, format='beos')
         self.assertEqual(len(font.glyphs), 14963)
         assert_text_eq(font.get_glyph('A').reduce().as_text(),  """\
-.171.
-17171
-71.17
-7...7
-7...7
-77777
-7...7
-7...7
+.2@2.
+2@2@2
+@2.2@
+@...@
+@...@
+@@@@@
+@...@
+@...@
 """)
 
     # Zap

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -1,0 +1,23 @@
+"""
+monobit test suite
+raster ink-level tests
+"""
+
+import unittest
+
+from monobit.core.raster import Raster
+
+
+class TestRaster(unittest.TestCase):
+    """Test raster ink levels."""
+
+    def test_rescale_ink(self):
+        """Rescaling preserves each pixel's share of full ink."""
+        raster = Raster.from_matrix([[0, 1], [7, 3]], inklevels=range(8))
+        rescaled = raster.rescale_ink(16)
+        self.assertEqual(rescaled.levels, 16)
+        self.assertEqual(rescaled.as_matrix(), ((0, 2), (15, 6)))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Background
Been working on parsing BeOS fonts as part of my [website](https://beta.mtechnic.me/) work. Needed to have some exact fonts for it ripped, but noticed some small bugs. I pulled the `.hpp` header files, and looked through them and updated the schema.

# Changes
 - improved struct
 - Safe quantization (to/from 16 levels from compatability, but BeOS is natively 7 levels)
 - Fixed unit tests
 - Made scaling code universal in raster/glyphs