### PR TITLE
Fix digits being omitted from DEC DRCS exports

### DIFF
--- a/monobit/storage/fontformats/softfont/dec.py
+++ b/monobit/storage/fontformats/softfont/dec.py
@@ -333,7 +333,7 @@ def _write_dec_drcs(font, outstream, use_8bit=False):
     esc = not use_8bit
     # we can only store the printable ascii range
     ascii = tuple(chr(_b) for _b in range(0x20, 0x80))
-    font = font.resample(ascii, missing='empty')
+    font = font.resample(chars=ascii, missing='empty')
     glyphs = font.glyphs
     # write 96 glyphs?
     is_big = not glyphs[0].is_blank() or not glyphs[-1].is_blank()


### PR DESCRIPTION
I'm working on an emulation of the Qume QVT-70 terminal and have used monobit to generate fonts to test its soft font capability. Currently there is a bug where numeric-looking character labels were being interpreted as codepoints, causing digit glyphs to be exported as empty characters.

Command used: `monobit-convert ANAKRON.bdf to anakron.dld --format=dec`

Screenshot before the fix:
<img width="1280" height="832" alt="0022d" src="https://github.com/user-attachments/assets/f6038430-a038-4a8e-838a-35f4088c764b" />

Screenshot after the fix:
<img width="1280" height="832" alt="0023d" src="https://github.com/user-attachments/assets/3bd9c8f6-67a3-4a98-bcc7-3a73180ad323" />

